### PR TITLE
Update npm dependencies to reflect package names

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "logout redirect"
   ],
   "dependencies": {
-    "JQuery": ">1.7",
-    "JQuery UI": ">1.9",
-    "store.js": "git://github.com/marcuswestin/store.js.git"
+    "jquery": ">1.7",
+    "jquery-ui": ">1.9",
+    "store": "^2.0.12"
   },
   "license": "CC-BY-SA-3.0",
   "bugs": {


### PR DESCRIPTION
The dependency information no longer resolves.  This fixes the package resolution when install via npm or yarn.