### PR TITLE
Update for jQuery update v3.6.0

### DIFF
--- a/jquery-idleTimeout.js
+++ b/jquery-idleTimeout.js
@@ -101,12 +101,12 @@
 
     //----------- ACTIVITY DETECTION FUNCTION --------------//
     activityDetector = function () {
-
-      $('body').on(currentConfig.activityEvents, function () {
-
-        if (!currentConfig.enableDialog || (currentConfig.enableDialog && isDialogOpen() !== true)) {
-          startIdleTimer();
-        }
+      $(document).ready(function() {
+        $('body').on(currentConfig.activityEvents, function () {
+          if (!currentConfig.enableDialog || (currentConfig.enableDialog && isDialogOpen() !== true)) {
+            startIdleTimer();
+          }
+        });
       });
     };
 


### PR DESCRIPTION
After jQuery update to 3.6.0, event binding is not working if document is not ready/loaded.